### PR TITLE
Fix self-reference.

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -8,7 +8,7 @@ import (
 	"net"
 	"net/http"
 
-	"github.com/ahmetalpbalkan/dlog"
+	"github.com/crowdsecurity/dlog"
 )
 
 func ExampleNewReader() {

--- a/reader_test.go
+++ b/reader_test.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/ahmetalpbalkan/dlog"
+	"github.com/crowdsecurity/dlog"
 )
 
 func Test_tooShortForPrefix(t *testing.T) {


### PR DESCRIPTION
It was forgotten when the switch from github.com/ahmetalpbalkan/dlog to github.com/ahmetb/dlog happened. Let's reference our own fork.